### PR TITLE
style: 홈, 검색화면, 로그인, 회원가입 스타일 피드백 적용

### DIFF
--- a/baribari/src/component/ContentContainer.tsx
+++ b/baribari/src/component/ContentContainer.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as FloatingRefreshBtn } from '../assets/RefreshBtn.svg';
 import { ContentContainerProps, DosirakItem } from '../utils/interface';
 import { useQuery } from '@tanstack/react-query';
 
-export default function ContentContainer({ keyword, filterLiked, sort }: ContentContainerProps) {
+export default function ContentContainer({ keyword, filterLiked, sort, setRefresh }: ContentContainerProps) {
     const navigate = useNavigate();
     const handleCardClick = (id: number) => {
         navigate(`/detail/${id}`); // 일단 detail로 넘어가는 걸로! 나중에 수정 예정.
@@ -52,10 +52,14 @@ export default function ContentContainer({ keyword, filterLiked, sort }: Content
                     <Price>{dosirak.price.toLocaleString()}원</Price>
                 </FoodCard>
             ))}
-            <RotateFloatingRefreshBtn
-                style={{ position: 'absolute', bottom: '0px', right: '10px' }}
-                onClick={() => refetch()}
-            />
+            {setRefresh ? (
+                <RotateFloatingRefreshBtn
+                    style={{ position: 'fixed', bottom: '90px', right: '12px' }}
+                    onClick={() => refetch()}
+                />
+            ) : (
+                ''
+            )}
         </Container>
     );
 }
@@ -75,6 +79,7 @@ const ImgWrapper = styled.div`
     position: relative;
     width: 100%;
     height: 206px;
+    margin-bottom: 12px;
 `;
 
 const StockTag = styled.div`
@@ -109,7 +114,7 @@ const FoodCard = styled.div`
     flex-direction: column;
     align-items: flex-start;
     display: flex;
-    padding: 0 0 20px 0px;
+    padding: 0 0 20px 0;
     // 카드 폭을 100%로 맞춰보는 건 어떨까!
     @media (max-width: 365px) {
         width: 100%;

--- a/baribari/src/component/DropDown.tsx
+++ b/baribari/src/component/DropDown.tsx
@@ -41,9 +41,9 @@ export default function DropDown({ onSelectSortOption }: { onSelectSortOption: (
             {viewOpen && (
                 <DropDownList>
                     <DropDownListItem onClick={() => handleSelectValue('최신순')}>최신순</DropDownListItem>
-                    <HorizontalLine />
+                    <HorizontalLine style={{ marginLeft: '12px' }} />
                     <DropDownListItem onClick={() => handleSelectValue('가격 낮은순')}>가격 낮은순</DropDownListItem>
-                    <HorizontalLine />
+                    <HorizontalLine style={{ marginLeft: '12px' }} />
                     <DropDownListItem onClick={() => handleSelectValue('가격 높은순')}>가격 높은순</DropDownListItem>
                 </DropDownList>
             )}
@@ -67,6 +67,7 @@ const DropDownButton = styled.button`
     border: none;
     background: #f9f9f9;
     text-align: center;
+    font-family: Pretendard Variable;
     font-size: 14px;
     font-style: normal;
     font-weight: 700;

--- a/baribari/src/component/HeartList.tsx
+++ b/baribari/src/component/HeartList.tsx
@@ -25,6 +25,7 @@ const HeartListButton = styled.button<{ $isclicked: boolean }>`
     background: ${(props) => (props.$isclicked ? '#fff1ee' : '#F9F9F9')};
     color: ${(props) => (props.$isclicked ? '#FF7455' : '#767676')};
     text-align: center;
+    font-family: Pretendard Variable;
     font-size: 14px;
     font-style: normal;
     font-weight: 700;

--- a/baribari/src/component/RandomTab.tsx
+++ b/baribari/src/component/RandomTab.tsx
@@ -22,7 +22,8 @@ export default function RandomTabs() {
                 <Container>
                     <Text>
                         <Header>
-                            매일 출석 체크하고 <Highlight>10%</Highlight> 할인 쿠폰 받아요!
+                            매일 출석 체크하고 <br />
+                            <Highlight>10%</Highlight> 할인 쿠폰 받아요!
                         </Header>
                         <SubHeader>
                             <LocaIcon />
@@ -35,7 +36,8 @@ export default function RandomTabs() {
                 <Container>
                     <Text>
                         <Header>
-                            바리바리에서 첫 구매시 <Highlight>15%</Highlight> 할인!
+                            건강한 한끼가 만드는 <br />
+                            <Highlight>행복</Highlight>을 느껴보세요!
                         </Header>
                         <SubHeader>
                             <LocaIcon />

--- a/baribari/src/component/SearchBar.tsx
+++ b/baribari/src/component/SearchBar.tsx
@@ -19,9 +19,8 @@ export default function SearchBar({ onKeywordChange }: { onKeywordChange: (keywo
 
     return (
         <SearchTab>
-
             <SearchInput
-                placeholder="반찬이름을 검색해보세요"
+                placeholder="반찬 메뉴를 검색해보세요"
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setKeyword(e.target.value)}
                 value={keyword}
             />
@@ -45,6 +44,7 @@ const SearchInput = styled.textarea`
     display: flex;
     color: #504e5f;
     align-items: center;
+    font-family: Pretendard Variable;
     font-size: 16px;
     font-style: normal;
     font-weight: 600;

--- a/baribari/src/page/Home.tsx
+++ b/baribari/src/page/Home.tsx
@@ -42,11 +42,10 @@ export default function Home() {
                 </InquiryTab>
                 <Link to="/search" style={{ textDecoration: 'none', width: 'calc(100% - 32px)' }}>
                     <SearchTab>
-                        <SearchText>반찬 이름을 검색해보세요</SearchText>
+                        <SearchText>반찬 메뉴를 검색해보세요</SearchText>
                         <SearchIcon
                             style={{
                                 display: 'flex',
-                                padding: '3px',
                                 alignContent: 'center',
                                 justifyContent: 'center',
                             }}
@@ -59,7 +58,12 @@ export default function Home() {
                     <HeartList filterLiked={filterLiked} onFilterLikedChange={setFilterLiked} />
                     <DropDown onSelectSortOption={(option) => setSelectedSortOption(option)} />
                 </Container>
-                <ContentContainer keyword={null} filterLiked={filterLiked} sort={selectedSortOption} />
+                <ContentContainer
+                    keyword={null}
+                    filterLiked={filterLiked}
+                    sort={selectedSortOption}
+                    setRefresh={true}
+                />
             </WrapperList>
             <WrapperNav>
                 <Navigator />
@@ -149,6 +153,7 @@ const SearchTab = styled.button`
     border: none;
     background-color: #efefef;
     color: #949494;
+    font-family: Pretendard Variable;
     font-size: 16px;
     font-style: normal;
     font-weight: 600;

--- a/baribari/src/page/Join.tsx
+++ b/baribari/src/page/Join.tsx
@@ -41,6 +41,11 @@ export default function Join() {
 
     const onSubmit: SubmitHandler<JoinData> = async (data) => {
         if (isValid) {
+            if (!state.all) {
+                alert('전체 동의를 확인해주세요!');
+                return;
+            }
+
             try {
                 // 회원가입 API 호출
                 const response = await registerUser(data.name, data.email, data.password, data.phone);
@@ -48,7 +53,7 @@ export default function Join() {
                 console.log('response:', response);
 
                 // 회원가입 성공 시 처리
-                alert('회원가입이 완료되었습니다!');
+                alert('회원가입이 완료되었습니다:)');
                 navigate('/'); // 회원가입 완료 후 이동할 페이지 설정
             } catch (error) {
                 // 실패 처리
@@ -178,12 +183,13 @@ const InputWrapper = styled.div`
 const Input = styled.input`
     height: 28px;
     padding: 8px 16px;
+    margin-bottom: 5px;
     border-radius: 8px;
     border: 0.75px solid #aaa;
     background: #fff;
     color: #504e5f;
     font-size: 16px;
-    font-family: 'Pretendard-Regular';
+    font-family: 'Pretendard Variable';
     font-style: normal;
     font-weight: 600;
     line-height: 28px;
@@ -193,12 +199,10 @@ const Input = styled.input`
     }
     &.is-invalid {
         border-color: red;
-        box-shadow: 0 0 5px 2px rgba(255, 0, 0, 0.3);
         transition: border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
     }
     &.is-valid {
         border-color: blue;
-        box-shadow: 0 0 5px 2px rgba(0, 0, 255, 0.3);
         transition: border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
     }
 `;
@@ -206,7 +210,7 @@ const Input = styled.input`
 const Label = styled.label`
     color: #767676;
     font-size: 12px;
-    font-family: Pretendard-Regular;
+    font-family: 'Pretendard Variable';
     font-style: normal;
     font-weight: 600;
     line-height: 28px;
@@ -225,12 +229,11 @@ const SubmitButton = styled.button`
     background: #ff7455;
     color: #fff;
     font-size: 24px;
-    font-family: Pretendard;
+    font-family: Pretendard Variable;
     font-weight: 700;
     border: none;
     align-items: center;
     justify-content: center;
-
     position: fixed;
     margin: 0 16px;
     bottom: 16px;

--- a/baribari/src/page/Login.tsx
+++ b/baribari/src/page/Login.tsx
@@ -36,9 +36,8 @@ export default function LogIn() {
             // 로그인 API 호출
             const response = await loginUser(data.email, data.password);
             // 로그인 성공 시 처리
+            alert('바리바리에 무사히 로그인하셨습니다:)');
             navigate('/home');
-            alert('로그인 성공!');
-            //navigate('/home');
         } catch (error) {
             // 로그인실패 처리
             alert('로그인 실패!');
@@ -138,7 +137,7 @@ const Input = styled.input`
     background: #fff;
     color: #504e5f;
     font-size: 16px;
-    font-family: 'Pretendard-Regular';
+    font-family: 'Pretendard Variable';
     font-style: normal;
     font-weight: 600;
     line-height: 28px;
@@ -148,12 +147,10 @@ const Input = styled.input`
     }
     &.is-invalid {
         border-color: red;
-        box-shadow: 0 0 5px 2px rgba(255, 0, 0, 0.3);
         transition: border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
     }
     &.is-valid {
         border-color: blue;
-        box-shadow: 0 0 5px 2px rgba(0, 0, 255, 0.3);
         transition: border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
     }
 `;
@@ -174,7 +171,7 @@ const SubmitButton = styled.button`
     background: #ff7455;
     color: #fff;
     font-size: 18px;
-    font-family: Pretendard-Regular;
+    font-family: 'Pretendard Variable';
     font-style: normal;
     font-weight: 700;
     line-height: 28px;

--- a/baribari/src/page/Search.tsx
+++ b/baribari/src/page/Search.tsx
@@ -27,7 +27,12 @@ export default function Search() {
                     <HeartList filterLiked={filterLiked} onFilterLikedChange={setFilterLiked} />
                     <DropDown onSelectSortOption={(option) => setSelectedSortOption(option)} />
                 </Container>
-                <ContentContainer keyword={debouncedSearchText} filterLiked={filterLiked} sort={selectedSortOption} />
+                <ContentContainer
+                    keyword={debouncedSearchText}
+                    filterLiked={filterLiked}
+                    sort={selectedSortOption}
+                    setRefresh={false}
+                />
             </Wrapper>
         </div>
     );

--- a/baribari/src/utils/interface.ts
+++ b/baribari/src/utils/interface.ts
@@ -30,6 +30,7 @@ export interface ContentContainerProps {
     keyword: string | null;
     filterLiked: boolean;
     sort: string | null;
+    setRefresh: boolean;
 }
 
 export interface DosirakItem {


### PR DESCRIPTION
## 수정사항

1. 홈 화면
- [x] 서치바 버튼에서 서치 아이콘 위치 조절
- [x] 버튼 전체적으로 폰트 Pretendard Variable로 지정 -> 드롭 다운, 찜 버튼 등 버튼들은 피그마에 나온대로 수정 완료
- [x] 드롭다운 구분선 스타일 변경 완료
- [x] 반찬 가게 카드 컴포넌트 gap 변경
- [x] 새로 고침 버튼 fixed로 변경 -> 이제 화면 우측 하단에 고정되어서 보임    

2. 검색창
- [x] 서치 바 디자인 홈 화면이랑 통일
- [x] 네비게이션 바 삭제
- [x] 플로팅 버튼 삭제  

3. 로그인
- [x] 파란색/빨간색 테두리 + 블러 효과였던 인풋 부분을 피드백을 수용해 블러 없애고 그냥 깔끔한 라인만 보이게 수정
- [x] textarea 폰트 pretendard variable 적용

4. 회원 가입
- [x] 파란색/빨간색 테두리 + 블러 효과였던 인풋 부분을 피드백을 수용해 블러 없애고 그냥 깔끔한 라인만 보이게 수정
- [x] textarea 폰트 pretendard variable 적용
- [x] 전체 동의 안 하면 페이지 안 넘어가게 라우팅 설정 